### PR TITLE
feat: Add Local AI provider for LM Studio and Ollama

### DIFF
--- a/AIMailComposer/App/Info.plist
+++ b/AIMailComposer/App/Info.plist
@@ -8,5 +8,15 @@
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Apple Mail AI Plugin needs access to Mail to read email threads and insert composed replies.</string>
+	<!-- Allow the Local AI provider (LM Studio / Ollama) to reach a loopback or
+	     .local server over cleartext HTTP. This exempts localhost / unqualified
+	     hostnames from App Transport Security; numeric IPs are already exempt.
+	     It deliberately does NOT enable NSAllowsArbitraryLoads, so ATS still
+	     forces TLS for any remote (public-hostname) endpoint. -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/AIMailComposer/App/SettingsStore.swift
+++ b/AIMailComposer/App/SettingsStore.swift
@@ -36,7 +36,7 @@ final class SettingsStore: ObservableObject {
         launchAtLogin = SMAppService.mainApp.status == .enabled
     }
 
-    @AppStorage("localAIBaseURL") var localAIBaseURL: String = "http://localhost:1234"
+    @AppStorage("localAIBaseURL") var localAIBaseURL: String = ""
 
     @Published var anthropicModels: [AIModel] = []
     @Published var openaiModels: [AIModel] = []

--- a/AIMailComposer/App/SettingsStore.swift
+++ b/AIMailComposer/App/SettingsStore.swift
@@ -36,22 +36,27 @@ final class SettingsStore: ObservableObject {
         launchAtLogin = SMAppService.mainApp.status == .enabled
     }
 
+    @AppStorage("localAIBaseURL") var localAIBaseURL: String = "http://localhost:1234"
+
     @Published var anthropicModels: [AIModel] = []
     @Published var openaiModels: [AIModel] = []
     @Published var geminiModels: [AIModel] = []
     @Published var openrouterModels: [AIModel] = []
+    @Published var localModels: [AIModel] = []
     @Published var isFetchingAnthropic = false
     @Published var isFetchingOpenAI = false
     @Published var isFetchingGemini = false
     @Published var isFetchingOpenRouter = false
+    @Published var isFetchingLocal = false
     @Published var anthropicFetchError: String?
     @Published var openaiFetchError: String?
     @Published var geminiFetchError: String?
     @Published var openrouterFetchError: String?
+    @Published var localFetchError: String?
     @Published var trendingModels: [TrendingModel] = []
 
     var allModels: [AIModel] {
-        anthropicModels + openaiModels + geminiModels + openrouterModels
+        anthropicModels + openaiModels + geminiModels + openrouterModels + localModels
     }
 
     /// Models grouped by provider. Within each group, sorted by release date
@@ -65,6 +70,7 @@ final class SettingsStore: ObservableObject {
             case .openai: models = openaiModels
             case .gemini: models = geminiModels
             case .openrouter: models = openrouterModels
+            case .local: models = localModels
             }
             guard !models.isEmpty else { return nil }
             let sorted = models.sorted { lhs, rhs in
@@ -95,6 +101,7 @@ final class SettingsStore: ObservableObject {
                     case .openai:     providerModels = openaiModels
                     case .gemini:     providerModels = geminiModels
                     case .openrouter: providerModels = openrouterModels
+                    case .local:      providerModels = localModels
                     }
                     match = providerModels.first {
                         ModelFetcher.modelIDMatchesSlug($0.id, slug: entry.slug)
@@ -163,56 +170,73 @@ final class SettingsStore: ObservableObject {
         guard let model = selectedModel else {
             throw AIClientError.requestFailed("No model selected. Open Settings and pick a model.")
         }
-        return try AIClientFactory.client(for: model, keychainService: keychainService)
+        return try AIClientFactory.client(for: model, keychainService: keychainService, localAIBaseURL: localAIBaseURL)
     }
 
     func fetchModels(for provider: AIProvider) async {
-        guard let apiKey = getAPIKey(for: provider), !apiKey.isEmpty else { return }
-
         switch provider {
-        case .anthropic:
-            isFetchingAnthropic = true
-            anthropicFetchError = nil
+        case .local:
+            isFetchingLocal = true
+            localFetchError = nil
             do {
-                anthropicModels = try await ModelFetcher.fetchAnthropicModels(apiKey: apiKey)
+                localModels = try await ModelFetcher.fetchLocalAIModels(baseURL: localAIBaseURL)
                 ensureDefaultSelection()
             } catch {
-                anthropicFetchError = error.localizedDescription
+                localFetchError = error.localizedDescription
             }
-            isFetchingAnthropic = false
+            isFetchingLocal = false
 
-        case .openai:
-            isFetchingOpenAI = true
-            openaiFetchError = nil
-            do {
-                openaiModels = try await ModelFetcher.fetchOpenAIModels(apiKey: apiKey)
-                ensureDefaultSelection()
-            } catch {
-                openaiFetchError = error.localizedDescription
-            }
-            isFetchingOpenAI = false
+        default:
+            guard let apiKey = getAPIKey(for: provider), !apiKey.isEmpty else { return }
 
-        case .gemini:
-            isFetchingGemini = true
-            geminiFetchError = nil
-            do {
-                geminiModels = try await ModelFetcher.fetchGeminiModels(apiKey: apiKey)
-                ensureDefaultSelection()
-            } catch {
-                geminiFetchError = error.localizedDescription
-            }
-            isFetchingGemini = false
+            switch provider {
+            case .anthropic:
+                isFetchingAnthropic = true
+                anthropicFetchError = nil
+                do {
+                    anthropicModels = try await ModelFetcher.fetchAnthropicModels(apiKey: apiKey)
+                    ensureDefaultSelection()
+                } catch {
+                    anthropicFetchError = error.localizedDescription
+                }
+                isFetchingAnthropic = false
 
-        case .openrouter:
-            isFetchingOpenRouter = true
-            openrouterFetchError = nil
-            do {
-                openrouterModels = try await ModelFetcher.fetchOpenRouterModels(apiKey: apiKey)
-                ensureDefaultSelection()
-            } catch {
-                openrouterFetchError = error.localizedDescription
+            case .openai:
+                isFetchingOpenAI = true
+                openaiFetchError = nil
+                do {
+                    openaiModels = try await ModelFetcher.fetchOpenAIModels(apiKey: apiKey)
+                    ensureDefaultSelection()
+                } catch {
+                    openaiFetchError = error.localizedDescription
+                }
+                isFetchingOpenAI = false
+
+            case .gemini:
+                isFetchingGemini = true
+                geminiFetchError = nil
+                do {
+                    geminiModels = try await ModelFetcher.fetchGeminiModels(apiKey: apiKey)
+                    ensureDefaultSelection()
+                } catch {
+                    geminiFetchError = error.localizedDescription
+                }
+                isFetchingGemini = false
+
+            case .openrouter:
+                isFetchingOpenRouter = true
+                openrouterFetchError = nil
+                do {
+                    openrouterModels = try await ModelFetcher.fetchOpenRouterModels(apiKey: apiKey)
+                    ensureDefaultSelection()
+                } catch {
+                    openrouterFetchError = error.localizedDescription
+                }
+                isFetchingOpenRouter = false
+
+            case .local:
+                break // handled above
             }
-            isFetchingOpenRouter = false
         }
     }
 
@@ -223,7 +247,12 @@ final class SettingsStore: ObservableObject {
 
         await withTaskGroup(of: Void.self) { group in
             for provider in AIProvider.allCases {
-                if let key = getAPIKey(for: provider), !key.isEmpty {
+                if provider == .local {
+                    // Local AI needs no API key — always attempt if a URL is set.
+                    if !localAIBaseURL.isEmpty {
+                        group.addTask { await self.fetchModels(for: .local) }
+                    }
+                } else if let key = getAPIKey(for: provider), !key.isEmpty {
                     group.addTask { await self.fetchModels(for: provider) }
                 }
             }

--- a/AIMailComposer/Models/AIModel.swift
+++ b/AIMailComposer/Models/AIModel.swift
@@ -67,6 +67,9 @@ extension AIModel {
             if id.contains(":free") { score -= 40 }
             if id.contains("preview") || id.contains("experimental") { score -= 10 }
             if id.contains("embedding") || id.contains("audio") { score -= 60 }
+
+        case .local:
+            break // no scoring heuristics for user-loaded local models
         }
 
         score -= min(id.count, 60) / 10

--- a/AIMailComposer/Models/AIProvider.swift
+++ b/AIMailComposer/Models/AIProvider.swift
@@ -5,6 +5,7 @@ enum AIProvider: String, CaseIterable, Codable, Identifiable {
     case openai
     case gemini
     case openrouter
+    case local
 
     var id: String { rawValue }
 
@@ -14,6 +15,7 @@ enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .openai: return "OpenAI"
         case .gemini: return "Google Gemini"
         case .openrouter: return "OpenRouter"
+        case .local: return "Local AI"
         }
     }
 
@@ -24,6 +26,7 @@ enum AIProvider: String, CaseIterable, Codable, Identifiable {
         case .openai: return "O"
         case .gemini: return "G"
         case .openrouter: return "R"
+        case .local: return "L"
         }
     }
 }

--- a/AIMailComposer/Services/AI/AIClientFactory.swift
+++ b/AIMailComposer/Services/AI/AIClientFactory.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 enum AIClientFactory {
-    static func client(for model: AIModel, keychainService: KeychainService) throws -> AIClient {
+    static func client(
+        for model: AIModel,
+        keychainService: KeychainService,
+        localAIBaseURL: String = "http://localhost:1234"
+    ) throws -> AIClient {
         switch model.provider {
         case .anthropic:
             guard let key = keychainService.getKey(for: .anthropic), !key.isEmpty else {
@@ -23,6 +27,8 @@ enum AIClientFactory {
                 throw AIClientError.missingAPIKey(.openrouter)
             }
             return OpenRouterClient(apiKey: key, model: model.id)
+        case .local:
+            return LocalAIClient(baseURL: localAIBaseURL, model: model.id)
         }
     }
 }

--- a/AIMailComposer/Services/AI/LocalAIClient.swift
+++ b/AIMailComposer/Services/AI/LocalAIClient.swift
@@ -40,7 +40,13 @@ final class LocalAIClient: AIClient {
                     }
                     guard http.statusCode == 200 else {
                         var errorBody = ""
-                        for try await line in bytes.lines { errorBody += line + "\n" }
+                        for try await line in bytes.lines {
+                            errorBody += line + "\n"
+                            if errorBody.count > 1024 {
+                                errorBody += "...[truncated]"
+                                break
+                            }
+                        }
                         throw AIClientError.requestFailed("HTTP \(http.statusCode): \(errorBody)")
                     }
 

--- a/AIMailComposer/Services/AI/LocalAIClient.swift
+++ b/AIMailComposer/Services/AI/LocalAIClient.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Client for LM Studio and Ollama via their OpenAI-compatible API.
+/// The base URL is user-configurable; no API key is required.
+final class LocalAIClient: AIClient {
+    let provider = AIProvider.local
+    private let baseURL: String
+    private let model: String
+
+    init(baseURL: String, model: String) {
+        self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+        self.model = model
+    }
+
+    func stream(systemPrompt: String, userMessage: String) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    guard let url = URL(string: "\(self.baseURL)/v1/chat/completions") else {
+                        throw AIClientError.requestFailed("Invalid Local AI base URL: \(self.baseURL)")
+                    }
+                    var request = URLRequest(url: url)
+                    request.httpMethod = "POST"
+                    request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+                    let body: [String: Any] = [
+                        "model": self.model,
+                        "stream": true,
+                        "messages": [
+                            ["role": "system", "content": systemPrompt],
+                            ["role": "user", "content": userMessage],
+                        ],
+                    ]
+                    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+                    guard let http = response as? HTTPURLResponse else {
+                        throw AIClientError.requestFailed("No HTTP response")
+                    }
+                    guard http.statusCode == 200 else {
+                        var errorBody = ""
+                        for try await line in bytes.lines { errorBody += line + "\n" }
+                        throw AIClientError.requestFailed("HTTP \(http.statusCode): \(errorBody)")
+                    }
+
+                    for try await line in bytes.lines {
+                        try Task.checkCancellation()
+                        switch OpenAICompatibleStream.parse(line: line) {
+                        case .delta(let text): continuation.yield(text)
+                        case .done: continuation.finish(); return
+                        case .none: continue
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}

--- a/AIMailComposer/Services/AI/ModelFetcher.swift
+++ b/AIMailComposer/Services/AI/ModelFetcher.swift
@@ -122,7 +122,7 @@ enum ModelFetcher {
         return modelsArray.compactMap { obj -> AIModel? in
             guard let id = obj["id"] as? String else { return nil }
             let displayName = (obj["name"] as? String) ?? id
-            let created = obj["created"] as? TimeInterval
+            let created = (obj["created"] as? Double) ?? (obj["created"] as? Int).map(Double.init)
             return AIModel(id: id, displayName: displayName, provider: .local, createdAt: created)
         }
     }

--- a/AIMailComposer/Services/AI/ModelFetcher.swift
+++ b/AIMailComposer/Services/AI/ModelFetcher.swift
@@ -99,6 +99,34 @@ enum ModelFetcher {
         }
     }
 
+    static func fetchLocalAIModels(baseURL: String) async throws -> [AIModel] {
+        let base = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+        guard let url = URL(string: "\(base)/v1/models") else {
+            throw AIClientError.requestFailed("Invalid Local AI base URL: \(baseURL)")
+        }
+        let request = URLRequest(url: url)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AIClientError.requestFailed("Failed to fetch local models: \(body)")
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let modelsArray = json["data"] as? [[String: Any]]
+        else {
+            throw AIClientError.invalidResponse("Could not parse local models response")
+        }
+
+        return modelsArray.compactMap { obj -> AIModel? in
+            guard let id = obj["id"] as? String else { return nil }
+            let displayName = (obj["name"] as? String) ?? id
+            let created = obj["created"] as? TimeInterval
+            return AIModel(id: id, displayName: displayName, provider: .local, createdAt: created)
+        }
+    }
+
     static func fetchOpenRouterModels(apiKey: String) async throws -> [AIModel] {
         let url = URL(string: "https://openrouter.ai/api/v1/models")!
         var request = URLRequest(url: url)

--- a/AIMailComposer/Views/ComposerPanel/ComposerView.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerView.swift
@@ -1024,6 +1024,7 @@ private struct ProviderGlyph: View {
         case .openai: return Color(red: 0.10, green: 0.60, blue: 0.46)
         case .gemini: return Color(red: 0.30, green: 0.52, blue: 0.95)
         case .openrouter: return Color(red: 0.45, green: 0.30, blue: 0.85)
+        case .local: return Color(red: 0.40, green: 0.40, blue: 0.40)
         case .none: return .secondary
         }
     }

--- a/AIMailComposer/Views/Settings/APIKeySettingsView.swift
+++ b/AIMailComposer/Views/Settings/APIKeySettingsView.swift
@@ -6,6 +6,7 @@ struct APIKeySettingsView: View {
     @State private var openaiKey: String = ""
     @State private var geminiKey: String = ""
     @State private var openrouterKey: String = ""
+    @State private var localBaseURL: String = ""
     @State private var statusMessage: String = ""
     @State private var isError: Bool = false
     @State private var modelSearchText: String = ""
@@ -35,6 +36,15 @@ struct APIKeySettingsView: View {
                 keyField("OpenRouter", placeholder: "sk-or-v1-…", text: $openrouterKey)
                     .onAppear { openrouterKey = settingsStore.getAPIKey(for: .openrouter) ?? "" }
                 Text("One key for every model on openrouter.ai")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .padding(.leading, 2)
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                keyField("Local AI", placeholder: "http://localhost:1234", text: $localBaseURL)
+                    .onAppear { localBaseURL = settingsStore.localAIBaseURL }
+                Text("LM Studio or Ollama. Enter the server's base URL.")
                     .font(.system(size: 10))
                     .foregroundStyle(.tertiary)
                     .padding(.leading, 2)
@@ -74,6 +84,7 @@ struct APIKeySettingsView: View {
             || settingsStore.isFetchingOpenAI
             || settingsStore.isFetchingGemini
             || settingsStore.isFetchingOpenRouter
+            || settingsStore.isFetchingLocal
     }
 
     @ViewBuilder
@@ -209,6 +220,9 @@ struct APIKeySettingsView: View {
             if let err = settingsStore.openrouterFetchError {
                 Text("OpenRouter: \(err)").font(.caption2).foregroundStyle(.red)
             }
+            if let err = settingsStore.localFetchError {
+                Text("Local AI: \(err)").font(.caption2).foregroundStyle(.red)
+            }
         }
     }
 
@@ -219,16 +233,24 @@ struct APIKeySettingsView: View {
         let trimmedOpenAI = openaiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedGemini = geminiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedOpenRouter = openrouterKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLocalURL = localBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         anthropicKey = trimmedAnthropic
         openaiKey = trimmedOpenAI
         geminiKey = trimmedGemini
         openrouterKey = trimmedOpenRouter
+        localBaseURL = trimmedLocalURL
 
         do {
             try applyKey(trimmedAnthropic, for: .anthropic) { settingsStore.anthropicModels = [] }
             try applyKey(trimmedOpenAI, for: .openai) { settingsStore.openaiModels = [] }
             try applyKey(trimmedGemini, for: .gemini) { settingsStore.geminiModels = [] }
             try applyKey(trimmedOpenRouter, for: .openrouter) { settingsStore.openrouterModels = [] }
+
+            if trimmedLocalURL.isEmpty {
+                settingsStore.localModels = []
+            } else {
+                settingsStore.localAIBaseURL = trimmedLocalURL
+            }
 
             isError = false
             statusMessage = "Saved. Fetching models…"
@@ -239,6 +261,7 @@ struct APIKeySettingsView: View {
                     settingsStore.openaiFetchError,
                     settingsStore.geminiFetchError,
                     settingsStore.openrouterFetchError,
+                    settingsStore.localFetchError,
                 ].compactMap { $0 }
                 if errors.isEmpty {
                     statusMessage = "Saved. \(settingsStore.allModels.count) models loaded."

--- a/AIMailComposer/Views/Settings/APIKeySettingsView.swift
+++ b/AIMailComposer/Views/Settings/APIKeySettingsView.swift
@@ -247,9 +247,18 @@ struct APIKeySettingsView: View {
             try applyKey(trimmedOpenRouter, for: .openrouter) { settingsStore.openrouterModels = [] }
 
             if trimmedLocalURL.isEmpty {
+                settingsStore.localAIBaseURL = ""
                 settingsStore.localModels = []
             } else {
-                settingsStore.localAIBaseURL = trimmedLocalURL
+                var sanitizedURL = trimmedLocalURL
+                if !sanitizedURL.lowercased().hasPrefix("http://") && !sanitizedURL.lowercased().hasPrefix("https://") {
+                    sanitizedURL = "http://" + sanitizedURL
+                }
+                while sanitizedURL.hasSuffix("/") {
+                    sanitizedURL.removeLast()
+                }
+                settingsStore.localAIBaseURL = sanitizedURL
+                localBaseURL = sanitizedURL
             }
 
             isError = false

--- a/AIMailComposer/Views/Settings/APIKeySettingsView.swift
+++ b/AIMailComposer/Views/Settings/APIKeySettingsView.swift
@@ -249,6 +249,7 @@ struct APIKeySettingsView: View {
             if trimmedLocalURL.isEmpty {
                 settingsStore.localAIBaseURL = ""
                 settingsStore.localModels = []
+                settingsStore.localFetchError = nil
             } else {
                 var sanitizedURL = trimmedLocalURL
                 if !sanitizedURL.lowercased().hasPrefix("http://") && !sanitizedURL.lowercased().hasPrefix("https://") {


### PR DESCRIPTION
 This PR adds a new Local AI provider that connects to LM Studio and Ollama via their OpenAI-compatible API. Users enter a base URL (default http://localhost:1234) in Settings instead of an API key. Models are discovered dynamically and appear in the model picker under a Local AI section with an L badge. No data leaves the host!