### PR TITLE
Protect Apple release signing credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Build and Release
 
 on:
-  push:
-    branches: [main]
+  # Signing credentials must only be exposed after a deliberate release action.
+  # Configure required reviewers for the `release` environment in GitHub.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -10,6 +11,7 @@ permissions:
 jobs:
   build-and-release:
     runs-on: macos-14
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -84,7 +86,7 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           security import "$CERT_PATH" -P "$CERTIFICATE_P12_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+            -T /usr/bin/codesign -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
@@ -106,7 +108,8 @@ jobs:
           xcrun notarytool store-credentials "AC_PASSWORD" \
             --apple-id "$APPLE_ID" \
             --team-id "$APPLE_TEAM_ID" \
-            --password "$APPLE_APP_SPECIFIC_PASSWORD"
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --keychain "$RUNNER_TEMP/build.keychain-db"
 
       - name: Build, sign, notarize, and package DMG
         if: steps.version.outputs.skip != 'true'
@@ -119,7 +122,8 @@ jobs:
             SIGNING_IDENTITY="Developer ID Application: Jan Philip Wahle ($APPLE_TEAM_ID)" \
             APPLE_ID="$APPLE_ID" \
             TEAM_ID="$APPLE_TEAM_ID" \
-            KEYCHAIN_PROFILE=AC_PASSWORD
+            KEYCHAIN_PROFILE=AC_PASSWORD \
+            KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
 
       - name: Verify Gatekeeper acceptance and universal binary
         if: steps.version.outputs.skip != 'true'

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,10 @@ notarize: sign
 	fi
 	@echo "Creating ZIP for notarization..."
 	@ditto -c -k --keepParent "$(APP_BUNDLE)" "$(BUILD_DIR)/$(BUNDLE_NAME).zip"
-	@if [ -n "$(KEYCHAIN_PROFILE)" ]; then \
+	@if [ -n "$(KEYCHAIN_PROFILE)" ] && [ -n "$(KEYCHAIN_PATH)" ]; then \
+		xcrun notarytool submit "$(BUILD_DIR)/$(BUNDLE_NAME).zip" \
+			--keychain-profile "$(KEYCHAIN_PROFILE)" --keychain "$(KEYCHAIN_PATH)" --wait; \
+	elif [ -n "$(KEYCHAIN_PROFILE)" ]; then \
 		xcrun notarytool submit "$(BUILD_DIR)/$(BUNDLE_NAME).zip" \
 			--keychain-profile "$(KEYCHAIN_PROFILE)" --wait; \
 	elif [ -n "$(APP_PASSWORD)" ]; then \
@@ -115,7 +118,10 @@ release-dmg: notarize
 	@rm -f "$(BUILD_DIR)/$(BUNDLE_NAME).dmg"
 	./scripts/create-dmg.sh "$(APP_NAME)" "$(APP_BUNDLE)" "$(BUILD_DIR)/$(BUNDLE_NAME).dmg"
 	codesign --force --sign "$(SIGNING_IDENTITY)" "$(BUILD_DIR)/$(BUNDLE_NAME).dmg"
-	@if [ -n "$(KEYCHAIN_PROFILE)" ]; then \
+	@if [ -n "$(KEYCHAIN_PROFILE)" ] && [ -n "$(KEYCHAIN_PATH)" ]; then \
+		xcrun notarytool submit "$(BUILD_DIR)/$(BUNDLE_NAME).dmg" \
+			--keychain-profile "$(KEYCHAIN_PROFILE)" --keychain "$(KEYCHAIN_PATH)" --wait; \
+	elif [ -n "$(KEYCHAIN_PROFILE)" ]; then \
 		xcrun notarytool submit "$(BUILD_DIR)/$(BUNDLE_NAME).dmg" \
 			--keychain-profile "$(KEYCHAIN_PROFILE)" --wait; \
 	else \


### PR DESCRIPTION
### Motivation

- The automated push-to-`main` release workflow exposed long-lived Developer ID signing keys and notarization credentials to repository-controlled build steps and left notarization credentials in the default keychain, creating a supply-chain risk. 

### Description

- Change the workflow trigger from an automatic `push` to an explicit `workflow_dispatch` and require the job to run in the protected `release` environment to ensure deliberate, reviewer-gated releases by humans. 
- Limit private-key access when importing the Developer ID certificate by replacing `security import ... -A` with an authorization limited to `/usr/bin/codesign` via `-T /usr/bin/codesign`. 
- Store notarization credentials in the temporary build keychain using `xcrun notarytool store-credentials ... --keychain "$RUNNER_TEMP/build.keychain-db"` and pass `KEYCHAIN_PATH` into the build step. 
- Update `Makefile` `notarize` and `release-dmg` paths to use the provided `KEYCHAIN_PATH` with `xcrun notarytool submit --keychain` when present, preserving the existing `--apple-id`/password fallback for local use. 

### Testing

- Ran `git diff --check` and `git diff` to validate patch formatting and reviewed file diffs successfully. 
- Validated workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "YAML OK"'` which printed `YAML OK`. 
- Performed a Makefile dry-run with `make -n release-dmg SIGNING_IDENTITY=test APPLE_ID=test TEAM_ID=test KEYCHAIN_PROFILE=AC_PASSWORD KEYCHAIN_PATH=/tmp/build.keychain-db` which exercised the updated `notarytool` invocations and produced the expected command paths. 
- Ran `swift test` in the Linux container which failed to build due to macOS-only `SwiftUI` being unavailable, so unit tests could not be executed here. 
- `actionlint` was not installed in the environment so workflow linting was not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b155e9050832c81c8aba150d33a57)