### PR TITLE
fix: read Mail compose window via Accessibility API on macOS 15+

### DIFF
--- a/AIMailComposer/Services/Mail/AXPermissionChecker.swift
+++ b/AIMailComposer/Services/Mail/AXPermissionChecker.swift
@@ -1,0 +1,28 @@
+import AppKit
+
+/// Checks and requests macOS Accessibility (AX) permission.
+///
+/// On macOS 15+ Mail's `outgoing messages` AppleScript collection is broken,
+/// so the app needs AX access to read the compose window's fields directly.
+enum AXPermissionChecker {
+
+    /// True if the app is trusted for Accessibility access.
+    static func isGranted() -> Bool {
+        AXIsProcessTrusted()
+    }
+
+    /// Trigger the system's one-time Accessibility permission prompt.
+    /// Returns the new trusted state (the prompt may have just been shown).
+    static func request() -> Bool {
+        let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true]
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
+    /// Open System Settings → Privacy & Security → Accessibility.
+    static func openSettings() {
+        let urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        if let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}

--- a/AIMailComposer/Services/Mail/AXPermissionChecker.swift
+++ b/AIMailComposer/Services/Mail/AXPermissionChecker.swift
@@ -2,8 +2,9 @@ import AppKit
 
 /// Checks and requests macOS Accessibility (AX) permission.
 ///
-/// On macOS 15+ Mail's `outgoing messages` AppleScript collection is broken,
-/// so the app needs AX access to read the compose window's fields directly.
+/// On recent macOS versions Mail's `outgoing messages` AppleScript collection
+/// is broken, so the app needs AX access to read the compose window's fields
+/// directly.
 enum AXPermissionChecker {
 
     /// True if the app is trusted for Accessibility access.

--- a/AIMailComposer/Services/Mail/AccessibilityReader.swift
+++ b/AIMailComposer/Services/Mail/AccessibilityReader.swift
@@ -110,9 +110,7 @@ enum AccessibilityReader {
                 acc.subject = axValue(element) ?? ""
             }
             if recipientFieldIDs.contains(id) {
-                if let addr = extractAddress(from: element), !addr.isEmpty {
-                    acc.recipients.append(addr)
-                }
+                acc.recipients.append(contentsOf: extractAddresses(from: element))
             }
         }
 
@@ -142,23 +140,49 @@ enum AccessibilityReader {
 
     // MARK: - Recipients
 
-    /// Recipient fields contain a child `AXStaticText` with the formatted
-    /// "Name <email>" string; the field's own value is just an attachment
-    /// placeholder. Walk direct children to find the static text.
-    private static func extractAddress(from field: AXUIElement) -> String? {
+    /// Extract individual recipient addresses from a recipient field.
+    ///
+    /// Each recipient token usually appears as a child `AXStaticText` with
+    /// the formatted "Name <email>" string. A typed-but-not-yet-tokenized
+    /// address may have no `AXStaticText` child yet — fall back to the
+    /// field's own value in that case. Returns one entry per address so
+    /// `recipientSummary` counts recipients, not fields.
+    private static func extractAddresses(from field: AXUIElement) -> [String] {
         var childrenRef: CFTypeRef?
         AXUIElementCopyAttributeValue(field, kAXChildrenAttribute as CFString, &childrenRef)
-        guard let children = childrenRef as? [AXUIElement] else { return nil }
+        let children = childrenRef as? [AXUIElement]
 
+        // Collect the static-text values of tokenized recipients.
         var parts: [String] = []
-        for child in children {
-            if let role = axRole(child), role == "AXStaticText" {
-                if let val = axValue(child), !val.isEmpty {
-                    parts.append(val)
+        if let children = children {
+            for child in children {
+                if let role = axRole(child), role == "AXStaticText" {
+                    if let val = axValue(child), !val.isEmpty {
+                        parts.append(val)
+                    }
                 }
             }
         }
-        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+
+        // Typed-but-not-tokenized: no token children, but the field itself
+        // carries the typed text as its value.
+        if parts.isEmpty, let val = axValue(field), !val.isEmpty {
+            parts.append(val)
+        }
+
+        // Each token is a single recipient; if a child value still holds a
+        // comma-joined list (some Mail layouts), split it so the count is
+        // per address rather than per field.
+        return parts.flatMap(splitAddresses)
+    }
+
+    /// Split a string into individual addresses on commas/semicolons,
+    /// trimming whitespace and dropping empty parts.
+    private static func splitAddresses(_ raw: String) -> [String] {
+        raw
+            .components(separatedBy: CharacterSet(charactersIn: ",;"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 
     // MARK: - AX helpers

--- a/AIMailComposer/Services/Mail/AccessibilityReader.swift
+++ b/AIMailComposer/Services/Mail/AccessibilityReader.swift
@@ -1,0 +1,206 @@
+import Foundation
+import AppKit
+
+/// Reads the Mail compose window's fields via the Accessibility (AX) API.
+///
+/// macOS 15 (Sequoia) and later broke Mail's `outgoing messages` AppleScript
+/// collection — it returns 0 even with a compose window open. This reader
+/// traverses Mail's AX tree to recover the subject, recipients, and draft
+/// content directly from the window's text fields.
+///
+/// Read-only: never sends keystrokes or modifies the compose window.
+enum AccessibilityReader {
+
+    struct ComposeContext {
+        let subject: String
+        let recipients: [String]
+        let draftContent: String
+    }
+
+    /// Traverse all Mail windows and return the context of the first one that
+    /// looks like a compose window (has a `Mail.subjectField` or a
+    /// `message body` web area). Returns `nil` if no compose window is found
+    /// or if the app lacks Accessibility permission.
+    static func readComposeWindow() -> ComposeContext? {
+        guard AXIsProcessTrusted() else { return nil }
+
+        guard let mailApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.mail").first else {
+            return nil
+        }
+        let app = AXUIElementCreateApplication(mailApp.processIdentifier)
+
+        var windowsRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsRef)
+        guard let windows = windowsRef as? [AXUIElement] else { return nil }
+
+        for window in windows {
+            if let ctx = readWindow(window) {
+                return ctx
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Per-window
+
+    /// Returns context if the given AX window is a Mail compose window.
+    private static func readWindow(_ window: AXUIElement) -> ComposeContext? {
+        // Compose windows contain a `Mail.subjectField` or a `message body` web area.
+        // Viewer windows have `Mail.messageViewer.window` ids and contain AXSplitGroup.
+        guard hasComposeMarker(window) else { return nil }
+
+        let subject = fieldValue(window, identifier: "Mail.subjectField") ?? ""
+        let recipients = collectRecipients(window)
+        let draft = readDraftBody(window)
+
+        return ComposeContext(
+            subject: subject,
+            recipients: recipients,
+            draftContent: draft
+        )
+    }
+
+    /// True if the window contains a compose-specific field id.
+    private static func hasComposeMarker(_ window: AXUIElement) -> Bool {
+        for id in ["Mail.subjectField", "Mail.toField"] {
+            if findFirst(window, identifier: id) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Recipients
+
+    /// Read all recipient fields (To, CC, BCC, Reply-To) and extract addresses.
+    private static func collectRecipients(_ window: AXUIElement) -> [String] {
+        var recipients: [String] = []
+        for id in ["Mail.toField", "Mail.ccField", "Mail.bccField"] {
+            if let field = findFirst(window, identifier: id) {
+                if let addr = extractAddress(from: field), !addr.isEmpty {
+                    recipients.append(addr)
+                }
+            }
+        }
+        return recipients
+    }
+
+    /// Recipient fields contain a child `AXStaticText` with the formatted
+    /// "Name <email>" string; the field's own value is just an attachment
+    /// placeholder. Walk children to find the static text.
+    private static func extractAddress(from field: AXUIElement) -> String? {
+        var childrenRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(field, kAXChildrenAttribute as CFString, &childrenRef)
+        guard let children = childrenRef as? [AXUIElement] else { return nil }
+
+        var parts: [String] = []
+        for child in children {
+            if let role = axRole(child), role == "AXStaticText" {
+                if let val = axValue(child), !val.isEmpty {
+                    parts.append(val)
+                }
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+
+    // MARK: - Draft body
+
+    /// Find the `AXWebArea` with description "message body" and concatenate
+    /// all `AXStaticText` children to recover the draft content.
+    private static func readDraftBody(_ window: AXUIElement) -> String {
+        guard let bodyArea = findFirst(window, role: "AXWebArea", description: "message body") else {
+            return ""
+        }
+        var lines: [String] = []
+        collectText(into: &lines, from: bodyArea)
+        return lines.joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Depth-first walk collecting `AXStaticText` / `AXTextArea` values.
+    private static func collectText(into lines: inout [String], from element: AXUIElement) {
+        if let role = axRole(element) {
+            if role == "AXStaticText" || role == "AXTextArea" {
+                if let val = axValue(element), !val.isEmpty {
+                    lines.append(val)
+                }
+            }
+        }
+        var childrenRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+        if let children = childrenRef as? [AXUIElement] {
+            for child in children {
+                collectText(into: &lines, from: child)
+            }
+        }
+    }
+
+    // MARK: - AX helpers
+
+    /// Find the first descendant matching an AXIdentifier.
+    private static func findFirst(_ element: AXUIElement, identifier: String) -> AXUIElement? {
+        if let id = axIdentifier(element), id == identifier {
+            return element
+        }
+        var childrenRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+        if let children = childrenRef as? [AXUIElement] {
+            for child in children {
+                if let found = findFirst(child, identifier: identifier) {
+                    return found
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Find the first descendant matching role + description.
+    private static func findFirst(_ element: AXUIElement, role: String, description: String) -> AXUIElement? {
+        if let r = axRole(element), r == role {
+            if let d = axDescription(element), d == description {
+                return element
+            }
+        }
+        var childrenRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+        if let children = childrenRef as? [AXUIElement] {
+            for child in children {
+                if let found = findFirst(child, role: role, description: description) {
+                    return found
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Read the `AXValue` of an element identified by `identifier`.
+    private static func fieldValue(_ element: AXUIElement, identifier: String) -> String? {
+        guard let target = findFirst(element, identifier: identifier) else { return nil }
+        return axValue(target)
+    }
+
+    private static func axRole(_ el: AXUIElement) -> String? {
+        var ref: CFTypeRef?
+        AXUIElementCopyAttributeValue(el, kAXRoleAttribute as CFString, &ref)
+        return ref as? String
+    }
+
+    private static func axDescription(_ el: AXUIElement) -> String? {
+        var ref: CFTypeRef?
+        AXUIElementCopyAttributeValue(el, kAXDescriptionAttribute as CFString, &ref)
+        return ref as? String
+    }
+
+    private static func axValue(_ el: AXUIElement) -> String? {
+        var ref: CFTypeRef?
+        AXUIElementCopyAttributeValue(el, kAXValueAttribute as CFString, &ref)
+        return ref as? String
+    }
+
+    private static func axIdentifier(_ el: AXUIElement) -> String? {
+        var ref: CFTypeRef?
+        AXUIElementCopyAttributeValue(el, kAXIdentifierAttribute as CFString, &ref)
+        return ref as? String
+    }
+}

--- a/AIMailComposer/Services/Mail/AccessibilityReader.swift
+++ b/AIMailComposer/Services/Mail/AccessibilityReader.swift
@@ -9,6 +9,12 @@ import AppKit
 /// content directly from the window's text fields.
 ///
 /// Read-only: never sends keystrokes or modifies the compose window.
+///
+/// Performance: every AX attribute read is an IPC round trip, and the main
+/// viewer window's tree (the message table) can be huge, so the reader
+/// (a) skips windows identified as `Mail.messageViewer.window` outright,
+/// (b) collects subject, recipients, and draft in a single recursive walk,
+/// and (c) sets a messaging timeout so a busy Mail can't hang the panel.
 enum AccessibilityReader {
 
     struct ComposeContext {
@@ -17,10 +23,19 @@ enum AccessibilityReader {
         let draftContent: String
     }
 
-    /// Traverse all Mail windows and return the context of the first one that
-    /// looks like a compose window (has a `Mail.subjectField` or a
-    /// `message body` web area). Returns `nil` if no compose window is found
-    /// or if the app lacks Accessibility permission.
+    /// Cap AX reads at this many seconds so a busy Mail doesn't stall the
+    /// panel. Individual attribute calls return `kAXErrorCannotComplete`
+    /// past it, which the walkers treat as "no value".
+    private static let messagingTimeout: Float = 1.5
+
+    private static let recipientFieldIDs: Set<String> = [
+        "Mail.toField", "Mail.ccField", "Mail.bccField",
+    ]
+
+    /// Traverse all Mail windows and return the context of the first one
+    /// that looks like a compose window (has a `Mail.subjectField` or
+    /// `Mail.toField`). Returns `nil` if no compose window is found or if
+    /// the app lacks Accessibility permission.
     static func readComposeWindow() -> ComposeContext? {
         guard AXIsProcessTrusted() else { return nil }
 
@@ -28,12 +43,18 @@ enum AccessibilityReader {
             return nil
         }
         let app = AXUIElementCreateApplication(mailApp.processIdentifier)
+        AXUIElementSetMessagingTimeout(app, messagingTimeout)
 
         var windowsRef: CFTypeRef?
         AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsRef)
         guard let windows = windowsRef as? [AXUIElement] else { return nil }
 
         for window in windows {
+            // Skip the main viewer window by identifier — its tree contains
+            // the message table and can be enormous.
+            if let id = axIdentifier(window), id == "Mail.messageViewer.window" {
+                continue
+            }
             if let ctx = readWindow(window) {
                 return ctx
             }
@@ -44,50 +65,86 @@ enum AccessibilityReader {
     // MARK: - Per-window
 
     /// Returns context if the given AX window is a Mail compose window.
+    /// Collects subject, recipients, and draft in a single recursive walk
+    /// instead of one traversal per field.
     private static func readWindow(_ window: AXUIElement) -> ComposeContext? {
-        // Compose windows contain a `Mail.subjectField` or a `message body` web area.
-        // Viewer windows have `Mail.messageViewer.window` ids and contain AXSplitGroup.
-        guard hasComposeMarker(window) else { return nil }
+        var acc = Walker()
+        walk(window, collectingBody: false, into: &acc)
+        guard acc.foundComposeMarker else { return nil }
 
-        let subject = fieldValue(window, identifier: "Mail.subjectField") ?? ""
-        let recipients = collectRecipients(window)
-        let draft = readDraftBody(window)
+        let draft = acc.draftLines
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return ComposeContext(
-            subject: subject,
-            recipients: recipients,
+            subject: acc.subject,
+            recipients: acc.recipients,
             draftContent: draft
         )
     }
 
-    /// True if the window contains a compose-specific field id.
-    private static func hasComposeMarker(_ window: AXUIElement) -> Bool {
-        for id in ["Mail.subjectField", "Mail.toField"] {
-            if findFirst(window, identifier: id) != nil {
-                return true
+    // MARK: - Single-walk accumulator
+
+    private struct Walker {
+        var subject = ""
+        var recipients: [String] = []
+        var draftLines: [String] = []
+        var foundComposeMarker = false
+    }
+
+    /// One depth-first pass that records the subject, recipient addresses,
+    /// and — once the `message body` web area is entered — all draft text.
+    private static func walk(
+        _ element: AXUIElement,
+        collectingBody: Bool,
+        into acc: inout Walker
+    ) {
+        let role = axRole(element)
+        let identifier = axIdentifier(element)
+
+        if let id = identifier {
+            if id == "Mail.subjectField" || id == "Mail.toField" {
+                acc.foundComposeMarker = true
+            }
+            if id == "Mail.subjectField" {
+                acc.subject = axValue(element) ?? ""
+            }
+            if recipientFieldIDs.contains(id) {
+                if let addr = extractAddress(from: element), !addr.isEmpty {
+                    acc.recipients.append(addr)
+                }
             }
         }
-        return false
+
+        // Enter the draft body web area — collect text from it and its
+        // descendants only, so subject/recipient text doesn't pollute it.
+        var inBody = collectingBody
+        if !inBody, let r = role, r == "AXWebArea" {
+            if axDescription(element) == "message body" {
+                inBody = true
+            }
+        }
+
+        if inBody, let r = role, r == "AXStaticText" || r == "AXTextArea" {
+            if let val = axValue(element), !val.isEmpty {
+                acc.draftLines.append(val)
+            }
+        }
+
+        var childrenRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+        if let children = childrenRef as? [AXUIElement] {
+            for child in children {
+                walk(child, collectingBody: inBody, into: &acc)
+            }
+        }
     }
 
     // MARK: - Recipients
 
-    /// Read all recipient fields (To, CC, BCC, Reply-To) and extract addresses.
-    private static func collectRecipients(_ window: AXUIElement) -> [String] {
-        var recipients: [String] = []
-        for id in ["Mail.toField", "Mail.ccField", "Mail.bccField"] {
-            if let field = findFirst(window, identifier: id) {
-                if let addr = extractAddress(from: field), !addr.isEmpty {
-                    recipients.append(addr)
-                }
-            }
-        }
-        return recipients
-    }
-
     /// Recipient fields contain a child `AXStaticText` with the formatted
     /// "Name <email>" string; the field's own value is just an attachment
-    /// placeholder. Walk children to find the static text.
+    /// placeholder. Walk direct children to find the static text.
     private static func extractAddress(from field: AXUIElement) -> String? {
         var childrenRef: CFTypeRef?
         AXUIElementCopyAttributeValue(field, kAXChildrenAttribute as CFString, &childrenRef)
@@ -104,81 +161,7 @@ enum AccessibilityReader {
         return parts.isEmpty ? nil : parts.joined(separator: ", ")
     }
 
-    // MARK: - Draft body
-
-    /// Find the `AXWebArea` with description "message body" and concatenate
-    /// all `AXStaticText` children to recover the draft content.
-    private static func readDraftBody(_ window: AXUIElement) -> String {
-        guard let bodyArea = findFirst(window, role: "AXWebArea", description: "message body") else {
-            return ""
-        }
-        var lines: [String] = []
-        collectText(into: &lines, from: bodyArea)
-        return lines.joined(separator: "\n")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    /// Depth-first walk collecting `AXStaticText` / `AXTextArea` values.
-    private static func collectText(into lines: inout [String], from element: AXUIElement) {
-        if let role = axRole(element) {
-            if role == "AXStaticText" || role == "AXTextArea" {
-                if let val = axValue(element), !val.isEmpty {
-                    lines.append(val)
-                }
-            }
-        }
-        var childrenRef: CFTypeRef?
-        AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
-        if let children = childrenRef as? [AXUIElement] {
-            for child in children {
-                collectText(into: &lines, from: child)
-            }
-        }
-    }
-
     // MARK: - AX helpers
-
-    /// Find the first descendant matching an AXIdentifier.
-    private static func findFirst(_ element: AXUIElement, identifier: String) -> AXUIElement? {
-        if let id = axIdentifier(element), id == identifier {
-            return element
-        }
-        var childrenRef: CFTypeRef?
-        AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
-        if let children = childrenRef as? [AXUIElement] {
-            for child in children {
-                if let found = findFirst(child, identifier: identifier) {
-                    return found
-                }
-            }
-        }
-        return nil
-    }
-
-    /// Find the first descendant matching role + description.
-    private static func findFirst(_ element: AXUIElement, role: String, description: String) -> AXUIElement? {
-        if let r = axRole(element), r == role {
-            if let d = axDescription(element), d == description {
-                return element
-            }
-        }
-        var childrenRef: CFTypeRef?
-        AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
-        if let children = childrenRef as? [AXUIElement] {
-            for child in children {
-                if let found = findFirst(child, role: role, description: description) {
-                    return found
-                }
-            }
-        }
-        return nil
-    }
-
-    /// Read the `AXValue` of an element identified by `identifier`.
-    private static func fieldValue(_ element: AXUIElement, identifier: String) -> String? {
-        guard let target = findFirst(element, identifier: identifier) else { return nil }
-        return axValue(target)
-    }
 
     private static func axRole(_ el: AXUIElement) -> String? {
         var ref: CFTypeRef?

--- a/AIMailComposer/Services/Mail/AccessibilityReader.swift
+++ b/AIMailComposer/Services/Mail/AccessibilityReader.swift
@@ -3,7 +3,7 @@ import AppKit
 
 /// Reads the Mail compose window's fields via the Accessibility (AX) API.
 ///
-/// macOS 15 (Sequoia) and later broke Mail's `outgoing messages` AppleScript
+/// Recent macOS versions broke Mail's `outgoing messages` AppleScript
 /// collection — it returns 0 even with a compose window open. This reader
 /// traverses Mail's AX tree to recover the subject, recipients, and draft
 /// content directly from the window's text fields.

--- a/AIMailComposer/Services/Mail/AccessibilityReader.swift
+++ b/AIMailComposer/Services/Mail/AccessibilityReader.swift
@@ -42,8 +42,12 @@ enum AccessibilityReader {
         guard let mailApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.mail").first else {
             return nil
         }
+        // The timeout must be set on the system-wide element: set on any
+        // other element it only caps messages to that element, so the
+        // child reads during the walk would still use the ~6s default.
+        AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), messagingTimeout)
+
         let app = AXUIElementCreateApplication(mailApp.processIdentifier)
-        AXUIElementSetMessagingTimeout(app, messagingTimeout)
 
         var windowsRef: CFTypeRef?
         AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsRef)

--- a/AIMailComposer/Services/Mail/MailBridge.swift
+++ b/AIMailComposer/Services/Mail/MailBridge.swift
@@ -67,10 +67,10 @@ final class MailBridge {
     }
 
     /// Pull context, falling back to the Accessibility reader when Mail's
-    /// `outgoing messages` AppleScript collection is empty (macOS 15+).
-    /// Never blocks on Accessibility permission: if AX isn't granted, the
-    /// AppleScript context is returned as-is so the UI can offer a
-    /// dismissible banner instead of a permission wall.
+    /// `outgoing messages` AppleScript collection is empty (recent macOS
+    /// versions). Never blocks on Accessibility permission: if AX isn't
+    /// granted, the AppleScript context is returned as-is so the UI can
+    /// offer a dismissible banner instead of a permission wall.
     static func fetchComposerContextWithAXFallback() async throws -> ComposerContext {
         guard await isMailRunning() else {
             throw MailBridgeError.mailNotRunning
@@ -85,9 +85,9 @@ final class MailBridge {
         let context = try MailThreadParser.parseComposerContext(raw)
 
         // If Pass 1 (outgoing messages) found nothing but Pass 2 identified
-        // a compose window by name, the AppleScript path is broken (macOS
-        // 15+). Fall back to the Accessibility reader when permission is
-        // granted; otherwise return the context as-is.
+        // a compose window by name, the AppleScript path is broken (recent
+        // macOS versions). Fall back to the Accessibility reader when
+        // permission is granted; otherwise return the context as-is.
         if context.recipients.isEmpty && context.currentDraft.isEmpty {
             return enrichViaAccessibility(context: context)
         }

--- a/AIMailComposer/Services/Mail/MailBridge.swift
+++ b/AIMailComposer/Services/Mail/MailBridge.swift
@@ -6,7 +6,6 @@ enum MailBridgeError: LocalizedError {
     case noComposer
     case mailNotRunning
     case parseError(String)
-    case accessibilityDenied
 
     var errorDescription: String? {
         switch self {
@@ -18,8 +17,6 @@ enum MailBridgeError: LocalizedError {
             return "Mail is not running. Open Mail and try again."
         case .parseError(let msg):
             return "Failed to parse Mail context: \(msg)"
-        case .accessibilityDenied:
-            return "Accessibility permission is needed to read your Mail compose window."
         }
     }
 }
@@ -71,8 +68,9 @@ final class MailBridge {
 
     /// Pull context, falling back to the Accessibility reader when Mail's
     /// `outgoing messages` AppleScript collection is empty (macOS 15+).
-    /// Throws `accessibilityDenied` if the AX fallback is required but
-    /// permission hasn't been granted.
+    /// Never blocks on Accessibility permission: if AX isn't granted, the
+    /// AppleScript context is returned as-is so the UI can offer a
+    /// dismissible banner instead of a permission wall.
     static func fetchComposerContextWithAXFallback() async throws -> ComposerContext {
         guard await isMailRunning() else {
             throw MailBridgeError.mailNotRunning
@@ -88,19 +86,21 @@ final class MailBridge {
 
         // If Pass 1 (outgoing messages) found nothing but Pass 2 identified
         // a compose window by name, the AppleScript path is broken (macOS
-        // 15+). Fall back to the Accessibility reader.
+        // 15+). Fall back to the Accessibility reader when permission is
+        // granted; otherwise return the context as-is.
         if context.recipients.isEmpty && context.currentDraft.isEmpty {
-            return try fetchViaAccessibility(context: context)
+            return enrichViaAccessibility(context: context)
         }
 
         return context
     }
 
-    /// Use the AX reader to populate recipients/subject/draft. If AX isn't
-    /// trusted, throw so the UI can guide the user to grant permission.
-    private static func fetchViaAccessibility(context: ComposerContext) throws -> ComposerContext {
+    /// Opportunistically enrich the context via the AX reader. If AX isn't
+    /// trusted or no compose window is found, the original context is
+    /// returned unchanged — never throws.
+    private static func enrichViaAccessibility(context: ComposerContext) -> ComposerContext {
         guard AXPermissionChecker.isGranted() else {
-            throw MailBridgeError.accessibilityDenied
+            return context
         }
 
         guard let ax = AccessibilityReader.readComposeWindow() else {

--- a/AIMailComposer/Services/Mail/MailBridge.swift
+++ b/AIMailComposer/Services/Mail/MailBridge.swift
@@ -50,28 +50,16 @@ final class MailBridge {
         }
     }
 
-    /// Pull context from the currently open Mail compose window.
-    /// Never reads from the message list — the compose window is the source of truth.
+    /// Pull context from the currently open Mail compose window, falling
+    /// back to the Accessibility reader when Mail's `outgoing messages`
+    /// AppleScript collection is empty (recent macOS versions). Never
+    /// blocks on Accessibility permission: if AX isn't granted, the
+    /// AppleScript context is returned as-is so the UI can offer a
+    /// dismissible banner instead of a permission wall.
+    ///
+    /// Never reads from the message list — the compose window is the source
+    /// of truth.
     static func fetchComposerContext() async throws -> ComposerContext {
-        guard await isMailRunning() else {
-            throw MailBridgeError.mailNotRunning
-        }
-
-        let raw = try await executeAppleScript(MailScripts.fetchComposerContext)
-
-        if raw.hasPrefix("ERROR:NO_COMPOSER") {
-            throw MailBridgeError.noComposer
-        }
-
-        return try MailThreadParser.parseComposerContext(raw)
-    }
-
-    /// Pull context, falling back to the Accessibility reader when Mail's
-    /// `outgoing messages` AppleScript collection is empty (recent macOS
-    /// versions). Never blocks on Accessibility permission: if AX isn't
-    /// granted, the AppleScript context is returned as-is so the UI can
-    /// offer a dismissible banner instead of a permission wall.
-    static func fetchComposerContextWithAXFallback() async throws -> ComposerContext {
         guard await isMailRunning() else {
             throw MailBridgeError.mailNotRunning
         }

--- a/AIMailComposer/Services/Mail/MailBridge.swift
+++ b/AIMailComposer/Services/Mail/MailBridge.swift
@@ -6,6 +6,7 @@ enum MailBridgeError: LocalizedError {
     case noComposer
     case mailNotRunning
     case parseError(String)
+    case accessibilityDenied
 
     var errorDescription: String? {
         switch self {
@@ -17,6 +18,8 @@ enum MailBridgeError: LocalizedError {
             return "Mail is not running. Open Mail and try again."
         case .parseError(let msg):
             return "Failed to parse Mail context: \(msg)"
+        case .accessibilityDenied:
+            return "Accessibility permission is needed to read your Mail compose window."
         }
     }
 }
@@ -64,6 +67,58 @@ final class MailBridge {
         }
 
         return try MailThreadParser.parseComposerContext(raw)
+    }
+
+    /// Pull context, falling back to the Accessibility reader when Mail's
+    /// `outgoing messages` AppleScript collection is empty (macOS 15+).
+    /// Throws `accessibilityDenied` if the AX fallback is required but
+    /// permission hasn't been granted.
+    static func fetchComposerContextWithAXFallback() async throws -> ComposerContext {
+        guard await isMailRunning() else {
+            throw MailBridgeError.mailNotRunning
+        }
+
+        let raw = try await executeAppleScript(MailScripts.fetchComposerContext)
+
+        if raw.hasPrefix("ERROR:NO_COMPOSER") {
+            throw MailBridgeError.noComposer
+        }
+
+        let context = try MailThreadParser.parseComposerContext(raw)
+
+        // If Pass 1 (outgoing messages) found nothing but Pass 2 identified
+        // a compose window by name, the AppleScript path is broken (macOS
+        // 15+). Fall back to the Accessibility reader.
+        if context.recipients.isEmpty && context.currentDraft.isEmpty {
+            return try fetchViaAccessibility(context: context)
+        }
+
+        return context
+    }
+
+    /// Use the AX reader to populate recipients/subject/draft. If AX isn't
+    /// trusted, throw so the UI can guide the user to grant permission.
+    private static func fetchViaAccessibility(context: ComposerContext) throws -> ComposerContext {
+        guard AXPermissionChecker.isGranted() else {
+            throw MailBridgeError.accessibilityDenied
+        }
+
+        guard let ax = AccessibilityReader.readComposeWindow() else {
+            // AX is granted but no compose window was found — return the
+            // original (possibly empty) context rather than failing.
+            return context
+        }
+
+        let thread = context.thread
+        let subject = ax.subject.isEmpty ? context.subject : ax.subject
+
+        return ComposerContext(
+            recipients: ax.recipients,
+            subject: subject,
+            currentDraft: ax.draftContent,
+            thread: thread,
+            composeWindowFrame: context.composeWindowFrame
+        )
     }
 
     /// Write the reply directly into the current Mail compose window.

--- a/AIMailComposer/Services/Mail/MailScripts.swift
+++ b/AIMailComposer/Services/Mail/MailScripts.swift
@@ -3,9 +3,15 @@ import Foundation
 enum MailScripts {
     /// Read context from the currently open compose window in Mail.
     ///
-    /// Implemented entirely against the Mail scripting dictionary — no System
-    /// Events / Accessibility calls — so the app only needs Automation
-    /// permission for Mail, nothing else.
+    /// This script is implemented entirely against the Mail scripting
+    /// dictionary — no System Events / Accessibility calls — so on its own
+    /// it only needs Automation permission for Mail. That guarantee no
+    /// longer holds for the app as a whole: when this path comes back
+    /// empty on recent macOS versions, `MailBridge` augments the result
+    /// via the Accessibility reader (`AccessibilityReader`). That widens
+    /// the permission footprint — AX can read every app's UI — which is a
+    /// deliberate trade-off recorded here rather than left as silent
+    /// comment rot.
     ///
     /// Detection priority:
     ///   1. `outgoing message 1` properties (best: gives recipients + draft)

--- a/AIMailComposer/Services/Mail/MailScripts.swift
+++ b/AIMailComposer/Services/Mail/MailScripts.swift
@@ -10,7 +10,7 @@ enum MailScripts {
     /// Detection priority:
     ///   1. `outgoing message 1` properties (best: gives recipients + draft)
     ///   2. Any Mail `window` that is not the `message viewer`'s window (the
-    ///      list/reading pane). This covers the macOS Sonoma/Sequoia case
+    ///      list/reading pane). This covers the case on newer macOS releases
     ///      where a brand-new blank compose window doesn't show up in
     ///      `outgoing messages`.
     static let fetchComposerContext = """

--- a/AIMailComposer/Views/ComposerPanel/ComposerView.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerView.swift
@@ -16,22 +16,32 @@ struct ComposerView: View {
             Divider()
                 .opacity(0.4)
 
+            if viewModel.showsAccessibilityBanner {
+                AXPermissionBanner(
+                    onGrant: {
+                        viewModel.requestAXPermission()
+                        viewModel.openAccessibilitySettings()
+                    },
+                    onRetry: { Task { await viewModel.retryAfterAXPermission() } },
+                    onDismiss: { viewModel.dismissAccessibilityBanner() }
+                )
+                Divider().opacity(0.4)
+            }
+
             contentArea
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            if !viewModel.needsAccessibilityPermission {
-                ComposerInputBar(
-                    userThoughts: $viewModel.userThoughts,
-                    isEditable: isInputEditable,
-                    isGenerating: viewModel.isBusy,
-                    canSend: viewModel.canSend,
-                    placeholder: inputPlaceholder,
-                    settingsStore: settingsStore,
-                    shouldFocus: viewModel.state == .ready || viewModel.state == .complete,
-                    claimsReturnShortcut: viewModel.state != .complete,
-                    onSend: { Task { await viewModel.generate() } }
-                )
-            }
+            ComposerInputBar(
+                userThoughts: $viewModel.userThoughts,
+                isEditable: isInputEditable,
+                isGenerating: viewModel.isBusy,
+                canSend: viewModel.canSend,
+                placeholder: inputPlaceholder,
+                settingsStore: settingsStore,
+                shouldFocus: viewModel.state == .ready || viewModel.state == .complete,
+                claimsReturnShortcut: viewModel.state != .complete,
+                onSend: { Task { await viewModel.generate() } }
+            )
         }
         .frame(minWidth: 500, minHeight: 500)
         .background(
@@ -54,16 +64,9 @@ struct ComposerView: View {
 
     @ViewBuilder
     private var contentArea: some View {
-        if viewModel.needsAccessibilityPermission {
-            AXPermissionState(
-                onRequest: { viewModel.requestAXPermission() },
-                onOpenSettings: { viewModel.openAccessibilitySettings() },
-                onRetry: { Task { await viewModel.retryAfterAXPermission() } }
-            )
-        } else {
-            switch viewModel.state {
-            case .loadingContext:
-                LoadingState(label: "Reading your compose window…")
+        switch viewModel.state {
+        case .loadingContext:
+            LoadingState(label: "Reading your compose window…")
 
             case .ready:
                 ReadyState(
@@ -97,9 +100,7 @@ struct ComposerView: View {
                     onRetry: { Task { await viewModel.retry() } }
                 )
             }
-        }
     }
-
     // MARK: Derived state
 
     private var isInputEditable: Bool {
@@ -704,44 +705,52 @@ private struct ErrorState: View {
     }
 }
 
-// MARK: - Accessibility permission
+// MARK: - Accessibility permission banner
 
-private struct AXPermissionState: View {
-    let onRequest: () -> Void
-    let onOpenSettings: () -> Void
+private struct AXPermissionBanner: View {
+    let onGrant: () -> Void
     let onRetry: () -> Void
+    let onDismiss: () -> Void
 
     var body: some View {
-        VStack(spacing: 16) {
-            Spacer()
+        HStack(alignment: .top, spacing: 10) {
             Image(systemName: "lock.shield.fill")
-                .font(.system(size: 28))
+                .font(.system(size: 16))
                 .foregroundStyle(.blue)
+                .padding(.top, 1)
 
-            Text("Accessibility Permission Needed")
-                .font(.system(size: 14, weight: .semibold))
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Accessibility helps read this reply")
+                    .font(.system(size: 12, weight: .semibold))
 
-            Text("macOS 26 changed how Mail exposes compose windows. "
-                 + "Accessibility access is needed to read your recipients, "
-                 + "subject, and draft directly from the compose window.")
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 36)
+                Text("Mail's AppleScript didn't expose the recipients or draft. "
+                     + "Grant Accessibility so the plugin can read them directly "
+                     + "from the compose window.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-            VStack(spacing: 8) {
-                Button("Grant Permission") {
-                    onRequest()
-                    onOpenSettings()
+                HStack(spacing: 8) {
+                    Button("Grant Accessibility", action: onGrant)
+                        .controlSize(.small)
+                    Button("Retry", action: onRetry)
+                        .controlSize(.small)
                 }
-                .controlSize(.regular)
-
-                Button("Retry") { onRetry() }
-                    .controlSize(.small)
             }
-            Spacer()
+
+            Spacer(minLength: 0)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 1)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Color.blue.opacity(0.06))
     }
 }
 

--- a/AIMailComposer/Views/ComposerPanel/ComposerView.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerView.swift
@@ -66,39 +66,40 @@ struct ComposerView: View {
         case .loadingContext:
             LoadingState(label: "Reading your compose window…")
 
-            case .ready:
-                ReadyState(
-                    context: viewModel.context,
-                    canSummarize: viewModel.canSummarize,
-                    isBusy: viewModel.isBusy,
-                    onSummarize: { Task { await viewModel.summarize() } }
-                )
+        case .ready:
+            ReadyState(
+                context: viewModel.context,
+                canSummarize: viewModel.canSummarize,
+                isBusy: viewModel.isBusy,
+                onSummarize: { Task { await viewModel.summarize() } }
+            )
 
-            case .generating:
-                GeneratingState(
-                    mode: viewModel.mode,
-                    thoughts: viewModel.userThoughts
-                )
+        case .generating:
+            GeneratingState(
+                mode: viewModel.mode,
+                thoughts: viewModel.userThoughts
+            )
 
-            case .complete:
-                ReplyResultView(
-                    reply: $viewModel.generatedReply,
-                    mode: viewModel.mode,
-                    userThoughts: viewModel.userThoughts,
-                    isStreaming: viewModel.isStreaming,
-                    onCopy: { viewModel.copyToClipboard() },
-                    onInsert: { Task { await viewModel.insertIntoMail() } },
-                    onRegenerate: { Task { await viewModel.regenerate() } },
-                    onEdit: { viewModel.backToEditing() }
-                )
+        case .complete:
+            ReplyResultView(
+                reply: $viewModel.generatedReply,
+                mode: viewModel.mode,
+                userThoughts: viewModel.userThoughts,
+                isStreaming: viewModel.isStreaming,
+                onCopy: { viewModel.copyToClipboard() },
+                onInsert: { Task { await viewModel.insertIntoMail() } },
+                onRegenerate: { Task { await viewModel.regenerate() } },
+                onEdit: { viewModel.backToEditing() }
+            )
 
-            case .error(let message):
-                ErrorState(
-                    message: message,
-                    onRetry: { Task { await viewModel.retry() } }
-                )
-            }
+        case .error(let message):
+            ErrorState(
+                message: message,
+                onRetry: { Task { await viewModel.retry() } }
+            )
+        }
     }
+
     // MARK: Derived state
 
     private var isInputEditable: Bool {

--- a/AIMailComposer/Views/ComposerPanel/ComposerView.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerView.swift
@@ -19,17 +19,19 @@ struct ComposerView: View {
             contentArea
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            ComposerInputBar(
-                userThoughts: $viewModel.userThoughts,
-                isEditable: isInputEditable,
-                isGenerating: viewModel.isBusy,
-                canSend: viewModel.canSend,
-                placeholder: inputPlaceholder,
-                settingsStore: settingsStore,
-                shouldFocus: viewModel.state == .ready || viewModel.state == .complete,
-                claimsReturnShortcut: viewModel.state != .complete,
-                onSend: { Task { await viewModel.generate() } }
-            )
+            if !viewModel.needsAccessibilityPermission {
+                ComposerInputBar(
+                    userThoughts: $viewModel.userThoughts,
+                    isEditable: isInputEditable,
+                    isGenerating: viewModel.isBusy,
+                    canSend: viewModel.canSend,
+                    placeholder: inputPlaceholder,
+                    settingsStore: settingsStore,
+                    shouldFocus: viewModel.state == .ready || viewModel.state == .complete,
+                    claimsReturnShortcut: viewModel.state != .complete,
+                    onSend: { Task { await viewModel.generate() } }
+                )
+            }
         }
         .frame(minWidth: 500, minHeight: 500)
         .background(
@@ -52,41 +54,49 @@ struct ComposerView: View {
 
     @ViewBuilder
     private var contentArea: some View {
-        switch viewModel.state {
-        case .loadingContext:
-            LoadingState(label: "Reading your compose window…")
-
-        case .ready:
-            ReadyState(
-                context: viewModel.context,
-                canSummarize: viewModel.canSummarize,
-                isBusy: viewModel.isBusy,
-                onSummarize: { Task { await viewModel.summarize() } }
+        if viewModel.needsAccessibilityPermission {
+            AXPermissionState(
+                onRequest: { viewModel.requestAXPermission() },
+                onOpenSettings: { viewModel.openAccessibilitySettings() },
+                onRetry: { Task { await viewModel.retryAfterAXPermission() } }
             )
+        } else {
+            switch viewModel.state {
+            case .loadingContext:
+                LoadingState(label: "Reading your compose window…")
 
-        case .generating:
-            GeneratingState(
-                mode: viewModel.mode,
-                thoughts: viewModel.userThoughts
-            )
+            case .ready:
+                ReadyState(
+                    context: viewModel.context,
+                    canSummarize: viewModel.canSummarize,
+                    isBusy: viewModel.isBusy,
+                    onSummarize: { Task { await viewModel.summarize() } }
+                )
 
-        case .complete:
-            ReplyResultView(
-                reply: $viewModel.generatedReply,
-                mode: viewModel.mode,
-                userThoughts: viewModel.userThoughts,
-                isStreaming: viewModel.isStreaming,
-                onCopy: { viewModel.copyToClipboard() },
-                onInsert: { Task { await viewModel.insertIntoMail() } },
-                onRegenerate: { Task { await viewModel.regenerate() } },
-                onEdit: { viewModel.backToEditing() }
-            )
+            case .generating:
+                GeneratingState(
+                    mode: viewModel.mode,
+                    thoughts: viewModel.userThoughts
+                )
 
-        case .error(let message):
-            ErrorState(
-                message: message,
-                onRetry: { Task { await viewModel.retry() } }
-            )
+            case .complete:
+                ReplyResultView(
+                    reply: $viewModel.generatedReply,
+                    mode: viewModel.mode,
+                    userThoughts: viewModel.userThoughts,
+                    isStreaming: viewModel.isStreaming,
+                    onCopy: { viewModel.copyToClipboard() },
+                    onInsert: { Task { await viewModel.insertIntoMail() } },
+                    onRegenerate: { Task { await viewModel.regenerate() } },
+                    onEdit: { viewModel.backToEditing() }
+                )
+
+            case .error(let message):
+                ErrorState(
+                    message: message,
+                    onRetry: { Task { await viewModel.retry() } }
+                )
+            }
         }
     }
 
@@ -688,6 +698,47 @@ private struct ErrorState: View {
                 .padding(.horizontal, 32)
             Button("Try again") { onRetry() }
                 .controlSize(.regular)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Accessibility permission
+
+private struct AXPermissionState: View {
+    let onRequest: () -> Void
+    let onOpenSettings: () -> Void
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "lock.shield.fill")
+                .font(.system(size: 28))
+                .foregroundStyle(.blue)
+
+            Text("Accessibility Permission Needed")
+                .font(.system(size: 14, weight: .semibold))
+
+            Text("macOS 26 changed how Mail exposes compose windows. "
+                 + "Accessibility access is needed to read your recipients, "
+                 + "subject, and draft directly from the compose window.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 36)
+
+            VStack(spacing: 8) {
+                Button("Grant Permission") {
+                    onRequest()
+                    onOpenSettings()
+                }
+                .controlSize(.regular)
+
+                Button("Retry") { onRetry() }
+                    .controlSize(.small)
+            }
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/AIMailComposer/Views/ComposerPanel/ComposerView.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerView.swift
@@ -18,10 +18,8 @@ struct ComposerView: View {
 
             if viewModel.showsAccessibilityBanner {
                 AXPermissionBanner(
-                    onGrant: {
-                        viewModel.requestAXPermission()
-                        viewModel.openAccessibilitySettings()
-                    },
+                    onGrant: { viewModel.requestAXPermission() },
+                    onOpenSettings: { viewModel.openAccessibilitySettings() },
                     onRetry: { Task { await viewModel.retryAfterAXPermission() } },
                     onDismiss: { viewModel.dismissAccessibilityBanner() }
                 )
@@ -709,6 +707,7 @@ private struct ErrorState: View {
 
 private struct AXPermissionBanner: View {
     let onGrant: () -> Void
+    let onOpenSettings: () -> Void
     let onRetry: () -> Void
     let onDismiss: () -> Void
 
@@ -732,6 +731,8 @@ private struct AXPermissionBanner: View {
 
                 HStack(spacing: 8) {
                     Button("Grant Accessibility", action: onGrant)
+                        .controlSize(.small)
+                    Button("Open Settings", action: onOpenSettings)
                         .controlSize(.small)
                     Button("Retry", action: onRetry)
                         .controlSize(.small)

--- a/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
@@ -29,6 +29,7 @@ final class ComposerViewModel: ObservableObject {
     /// True when the AppleScript path came back empty for a reply (the API
     /// is lying — a reply always has recipients) and Accessibility isn't
     /// granted. Shown as a dismissible banner, never as a blocking wall.
+    /// Set in `activate()` after `MailBridge.fetchComposerContext()`.
     @Published var showsAccessibilityBanner = false
 
     var canSummarize: Bool {
@@ -63,7 +64,7 @@ final class ComposerViewModel: ObservableObject {
         state = .loadingContext
         showsAccessibilityBanner = false
         do {
-            let context = try await MailBridge.fetchComposerContextWithAXFallback()
+            let context = try await MailBridge.fetchComposerContext()
             self.context = context
             // Sharp "AppleScript is actually broken" signal: a reply always
             // has recipients, so a non-empty thread with no recipients means

--- a/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
@@ -26,10 +26,10 @@ final class ComposerViewModel: ObservableObject {
     @Published var isStreaming: Bool = false
     @Published private(set) var mode: Mode = .reply
     @Published private(set) var context: ComposerContext?
-    /// True when the AX permission prompt should be shown instead of the
-    /// normal composer UI. Set when `fetchComposerContextWithAXFallback`
-    /// throws `accessibilityDenied`.
-    @Published var needsAccessibilityPermission = false
+    /// True when the AppleScript path came back empty for a reply (the API
+    /// is lying — a reply always has recipients) and Accessibility isn't
+    /// granted. Shown as a dismissible banner, never as a blocking wall.
+    @Published var showsAccessibilityBanner = false
 
     var canSummarize: Bool {
         guard let context else { return false }
@@ -61,25 +61,34 @@ final class ComposerViewModel: ObservableObject {
 
     func activate() async {
         state = .loadingContext
-        needsAccessibilityPermission = false
+        showsAccessibilityBanner = false
         do {
             let context = try await MailBridge.fetchComposerContextWithAXFallback()
             self.context = context
+            // Sharp "AppleScript is actually broken" signal: a reply always
+            // has recipients, so a non-empty thread with no recipients means
+            // the API is lying. A blank new-message compose (thread == nil)
+            // is legitimately empty and must not trigger the banner.
+            showsAccessibilityBanner =
+                !AXPermissionChecker.isGranted()
+                && context.thread != nil
+                && context.recipients.isEmpty
             state = .ready
         } catch let error as MailBridgeError {
-            if case .accessibilityDenied = error {
-                needsAccessibilityPermission = true
-                state = .error(error.errorDescription ?? "Accessibility required")
-            } else {
-                state = .error(error.errorDescription ?? "Unknown error")
-            }
+            state = .error(error.errorDescription ?? "Unknown error")
         } catch {
             state = .error(error.localizedDescription)
         }
     }
 
-    /// Called after the user grants Accessibility permission in System
-    /// Settings and taps "Retry" in the permission view.
+    /// Dismiss the accessibility banner without granting permission. The
+    /// banner reappears on the next activation if the condition still holds.
+    func dismissAccessibilityBanner() {
+        showsAccessibilityBanner = false
+    }
+
+    /// Re-fetch context after the user grants Accessibility permission in
+    /// System Settings and taps "Retry" in the banner.
     func retryAfterAXPermission() async {
         await activate()
     }

--- a/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
@@ -75,8 +75,6 @@ final class ComposerViewModel: ObservableObject {
                 && context.thread != nil
                 && context.recipients.isEmpty
             state = .ready
-        } catch let error as MailBridgeError {
-            state = .error(error.errorDescription ?? "Unknown error")
         } catch {
             state = .error(error.localizedDescription)
         }

--- a/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
+++ b/AIMailComposer/Views/ComposerPanel/ComposerViewModel.swift
@@ -26,6 +26,10 @@ final class ComposerViewModel: ObservableObject {
     @Published var isStreaming: Bool = false
     @Published private(set) var mode: Mode = .reply
     @Published private(set) var context: ComposerContext?
+    /// True when the AX permission prompt should be shown instead of the
+    /// normal composer UI. Set when `fetchComposerContextWithAXFallback`
+    /// throws `accessibilityDenied`.
+    @Published var needsAccessibilityPermission = false
 
     var canSummarize: Bool {
         guard let context else { return false }
@@ -57,13 +61,37 @@ final class ComposerViewModel: ObservableObject {
 
     func activate() async {
         state = .loadingContext
+        needsAccessibilityPermission = false
         do {
-            let context = try await MailBridge.fetchComposerContext()
+            let context = try await MailBridge.fetchComposerContextWithAXFallback()
             self.context = context
             state = .ready
+        } catch let error as MailBridgeError {
+            if case .accessibilityDenied = error {
+                needsAccessibilityPermission = true
+                state = .error(error.errorDescription ?? "Accessibility required")
+            } else {
+                state = .error(error.errorDescription ?? "Unknown error")
+            }
         } catch {
             state = .error(error.localizedDescription)
         }
+    }
+
+    /// Called after the user grants Accessibility permission in System
+    /// Settings and taps "Retry" in the permission view.
+    func retryAfterAXPermission() async {
+        await activate()
+    }
+
+    /// Open System Settings → Privacy & Security → Accessibility.
+    func openAccessibilitySettings() {
+        AXPermissionChecker.openSettings()
+    }
+
+    /// Trigger the system's one-time AX permission prompt.
+    func requestAXPermission() {
+        _ = AXPermissionChecker.request()
     }
 
     func generate() async {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The **Apple Mail AI Plugin** lives in your menu bar and connects directly to App
 
 ## Installation
 
-**Requirements:** macOS 14 (Sonoma) or later. On macOS 15 (Sequoia) and later, Mail's AppleScript interface no longer exposes compose windows, so the app uses the Accessibility API to read your draft — grant **Accessibility** permission when prompted (System Settings → Privacy & Security → Accessibility).
+**Requirements:** macOS 14 (Sonoma) or later. On macOS 15 (Sequoia) and later, Mail's AppleScript interface no longer exposes compose windows, so the app can optionally use the Accessibility API to read your draft — grant **Accessibility** permission when the in-app banner suggests it (System Settings → Privacy & Security → Accessibility). The banner is dismissible; a blank new-message compose keeps working without it.
 
 ### Download
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The **Apple Mail AI Plugin** lives in your menu bar and connects directly to App
 
 ## Installation
 
-**Requirements:** macOS 14 (Sonoma) or later
+**Requirements:** macOS 14 (Sonoma) or later. On macOS 15 (Sequoia) and later, Mail's AppleScript interface no longer exposes compose windows, so the app uses the Accessibility API to read your draft — grant **Accessibility** permission when prompted (System Settings → Privacy & Security → Accessibility).
 
 ### Download
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The **Apple Mail AI Plugin** lives in your menu bar and connects directly to App
 
 ## Installation
 
-**Requirements:** macOS 14 (Sonoma) or later. On macOS 15 (Sequoia) and later, Mail's AppleScript interface no longer exposes compose windows, so the app can optionally use the Accessibility API to read your draft — grant **Accessibility** permission when the in-app banner suggests it (System Settings → Privacy & Security → Accessibility). The banner is dismissible; a blank new-message compose keeps working without it.
+**Requirements:** macOS 14 (Sonoma) or later. On recent macOS versions, Mail's AppleScript interface no longer reliably exposes compose windows, so the app can optionally use the Accessibility API to read your draft — grant **Accessibility** permission when the in-app banner suggests it (System Settings → Privacy & Security → Accessibility). The banner is dismissible; a blank new-message compose keeps working without it.
 
 ### Download
 


### PR DESCRIPTION
Access to text of mail draft and recipients did not work on my machine (MacOS 26 ARM). The AI proposed to change the way the mail data is accessed. It works for me but I'm not sure it'S the best way to do it - feedback welcome.

macOS 15 (Sequoia) and later broke Mail's `outgoing messages` AppleScript collection — it returns 0 even with a compose window open, so recipients, draft, and thread were all empty.

Add an Accessibility (AX) fallback that traverses Mail's AX tree to read compose fields directly via stable identifiers (`Mail.toField`, `Mail.subjectField`, `message body` web area).

- AccessibilityReader: read-only AX field traversal
- AXPermissionChecker: TCC check + system prompt + deep-link
- MailBridge: fallback to AX when AppleScript returns empty
- ComposerViewModel: handle accessibilityDenied state
- ComposerView: AXPermissionState view with grant/retry buttons
- README: document macOS 15+ AX permission requirement

Created using OpenCode and GLM 5.2