### PR TITLE
Fix sample provider/model.

### DIFF
--- a/AIMailComposer/Models/AIModel.swift
+++ b/AIMailComposer/Models/AIModel.swift
@@ -60,7 +60,7 @@ extension AIModel {
 
         case .openrouter, .trustedtokens:
             // OpenRouter and TrustedTokens both pass slugs like
-            // `anthropic/claude-sonnet-4` / `skainet/zai-org/GLM-5.2`. Favour
+            // `anthropic/claude-sonnet-4` / `zai-org/GLM-5.3`. Favour
             // flagship families, penalise free/preview/deprecated tags and
             // non-text modalities.
             if id.contains("opus") || id.contains("gpt-5") || id.contains("o4") || id.contains("2.5-pro") || id.contains("glm-5") { score += 40 }

--- a/AIMailComposer/Services/AI/TrustedTokensClient.swift
+++ b/AIMailComposer/Services/AI/TrustedTokensClient.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// TrustedTokens (trustedtokens.eu) exposes an OpenAI-compatible chat
 /// completions contract, so this client mirrors `OpenAIClient` with a
-/// different base URL. Model ids follow the `provider/model` convention
-/// (e.g. `skainet/zai-org/GLM-5.2`) and are sent verbatim. Selection is
+/// different base URL. Model IDs are sent verbatim, whether bare
+/// (e.g. `zai-org/GLM-5.3`) or prefixed with a route (e.g. `skainet/`). Selection is
 /// keyed by provider + id (see `SettingsStore.selectModel`) so an id that
 /// also exists on OpenRouter resolves to whichever copy the user picked.
 final class TrustedTokensClient: AIClient {

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The Apple Mail AI Plugin calls AI providers directly. Add a provider API key or 
 3. Open **Account** to find your API token
 4. Copy the token
 
-> **Tip:** TrustedTokens is an EU-sovereign, OpenAI-compatible gateway hosted in Germany — all data processed in the EU. Model ids follow the `provider/model` convention (e.g. `skainet/zai-org/GLM-5.2`).
+> **Tip:** TrustedTokens is an EU-sovereign, OpenAI-compatible gateway hosted in Germany — all data processed in the EU. Model ids follow the `provider/model` convention (e.g. `zai-org/GLM-5.3`).
 
 ### Local or Custom OpenAI-Compatible Server
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The Apple Mail AI Plugin calls AI providers directly. Add a provider API key or 
 3. Open **Account** to find your API token
 4. Copy the token
 
-> **Tip:** TrustedTokens is an EU-sovereign, OpenAI-compatible gateway hosted in Germany — all data processed in the EU. Model ids follow the `provider/model` convention (e.g. `zai-org/GLM-5.3`).
+> **Tip:** TrustedTokens is an EU-sovereign, OpenAI-compatible gateway hosted in Germany — all data processed in the EU. The app fetches model IDs automatically and sends the selected ID unchanged. Default-provider entries use a bare model ID (e.g. `zai-org/GLM-5.3`); provider-specific entries include a routing prefix (e.g. `skainet/zai-org/GLM-5.3`). See the [TrustedTokens API documentation](https://trustedtokens.eu/docs/) for details.
 
 ### Local or Custom OpenAI-Compatible Server
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -708,7 +708,7 @@
             </div>
             <div class="mviz-row" data-mviz-row>
               <div class="mviz-dot" style="background:#1A59D9;"></div>
-              <div class="mviz-body"><div class="mviz-name">TrustedTokens</div><div class="mviz-sub">skainet/zai-org/GLM-5.2</div></div>
+              <div class="mviz-body"><div class="mviz-name">TrustedTokens</div><div class="mviz-sub">zai-org/GLM-5.3</div></div>
               <div class="mviz-check">✓</div>
             </div>
           </div>


### PR DESCRIPTION
I don't know whether it was used before, but as of today, the model id tor trustedtokens.eu is only provider/model.